### PR TITLE
Update icons to FontAwesome5

### DIFF
--- a/assets/javascripts/mumuki-emojis.js
+++ b/assets/javascripts/mumuki-emojis.js
@@ -77,7 +77,7 @@ $.fn.renderMumukiEmojis = function () {
     },
 
     dropdownToggleIconClass: function () {
-      return this.$element.data('icon-class') || 'fa fa-fw fa-smile-o';
+      return this.$element.data('icon-class') || 'far fa-fw fa-smile';
     },
 
     dropdownMenuAlignmentClass: function () {
@@ -334,7 +334,7 @@ $.fn.renderMumukiEmojis = function () {
 
     createIcon: function () {
       this.$icon = $('<i>', {
-        class: [MuEmoji.DROPDOWN_MENU_SEARCH_ICON, 'fa fa-fw fa-search'].join(' '),
+        class: [MuEmoji.DROPDOWN_MENU_SEARCH_ICON, 'fas fa-fw fa-search'].join(' '),
       });
       this.$element.append(this.$icon);
     },


### PR DESCRIPTION
## :dart: Goal

Use FontAwesome5 syntax for icons.

## :spiral_notepad: Notes

The biggest change on FA5 is that instead of having solid and outlined icons with different `fa-` prefixes (such as `fa-user` and `fa-user-o`), the style is now dictated by `fas` (s for solid), `far` (r for regular) and `fab` (b for brand). Therefore, `fas fa-user` shows a solid user icon, `far fa-user` shows the outlined style, and `fab fa-twitter` is the style for brand icons.
